### PR TITLE
Add proc_dops member to proc_dir_entry struct

### DIFF
--- a/include/network_hooks.h
+++ b/include/network_hooks.h
@@ -38,6 +38,9 @@ struct proc_dir_entry {
 	struct completion *pde_unload_completion;
 	const struct inode_operations *proc_iops;
 	const struct file_operations *proc_fops;
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(4,19,29)
+	const struct dentry_operations *proc_dops;
+#endif
 	union {
 		const struct seq_operations *seq_ops;
 		int (*single_show)(struct seq_file *, void *);


### PR DESCRIPTION
This member was added in kernel 4.19.29 [1].  Adding this member to the
redefined proc_dir_entry structure fixes the following bug on Debian 10:

    BUG: unable to handle kernel NULL pointer dereference at 0000000000000000

    RSP: 0018:ffffc90000597df0 EFLAGS: 00010246
    RAX: 0000000000000000 RBX: ffffffff8209a8a0 RCX: 0000000000000006
    RDX: 0000000000000000 RSI: ffffffffc044d48c RDI: 0000000000000000

    Call Trace:
     find_subdir+0x2e/0x50 [tyton]
     analyze_networks+0x81/0xa0 [tyton]
     work_func+0x14/0x50 [tyton]
     process_one_work+0x1a7/0x3a0
     worker_thread+0x30/0x390
     ? create_worker+0x1a0/0x1a0
     kthread+0x112/0x130
     ? kthread_bind+0x30/0x30
     ret_from_fork+0x35/0x40

[1] https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/commit/fs/proc/internal.h?id=1fde6f21d90f8ba5da3cb9c54ca991ed72696c43