### PR TITLE
Fix for #29

### DIFF
--- a/include/util.h
+++ b/include/util.h
@@ -3,4 +3,6 @@
 
 struct module *get_module_from_addr(unsigned long);
 
+extern unsigned long lookup_name(const char *);
+
 #endif /* UTIL_H */

--- a/src/core.c
+++ b/src/core.c
@@ -1,6 +1,7 @@
 #include <linux/workqueue.h>
 
 #include "core.h"
+#include "util.h"
 #include "proc.h"
 #include "logger.h"
 #include "module_list.h"
@@ -41,9 +42,9 @@ void exit_del_workqueue(void){
 }
 
 static void init_kernel_syms(void){
-	idt = (void *)kallsyms_lookup_name("idt_table");
-	sct = (void *)kallsyms_lookup_name("sys_call_table");
-	ckt = (void *)kallsyms_lookup_name("core_kernel_text");
+	idt = (void *)lookup_name("idt_table");
+	sct = (void *)lookup_name("sys_call_table");
+	ckt = (void *)lookup_name("core_kernel_text");
 }
 
 static int __init init_mod(void){

--- a/src/module_list.c
+++ b/src/module_list.c
@@ -14,7 +14,7 @@ const char *find_hidden_module(unsigned long addr){
 	struct kobject *cur, *tmp;
 	struct module_kobject *kobj;
 
-	mod_kset = (void *)kallsyms_lookup_name("module_kset");
+	mod_kset = (void *)lookup_name("module_kset");
 	if (!mod_kset)
 		return NULL;
 
@@ -47,7 +47,7 @@ void analyze_modules(void){
 
 	INFO("Analyzing Module List\n");
 
-	mod_kset = (void *)kallsyms_lookup_name("module_kset");
+	mod_kset = (void *)lookup_name("module_kset");
 	if (!mod_kset)
 		return;
 

--- a/src/util.c
+++ b/src/util.c
@@ -1,6 +1,33 @@
+#include <linux/kallsyms.h>
+
 #include "core.h"
 #include "util.h"
 
 struct module *get_module_from_addr(unsigned long addr){
 	return  __module_address(addr);
 }
+
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(5,7,0)
+
+#include <linux/kprobes.h>
+
+static struct kprobe kp;
+
+unsigned long lookup_name(const char *name){
+	kp.symbol_name = name;
+
+	if (register_kprobe(&kp) < 0)
+		return 0;
+
+	unregister_kprobe(&kp);
+
+	return (unsigned long)kp.addr;
+}
+
+#else
+
+unsigned long lookup_name(const char *name){
+	return kallsyms_lookup_name(name);
+}
+
+#endif


### PR DESCRIPTION
Due to [recent unexport][1] of the kallsyms_lookup_name function, the [kprobe trick][2] suggested is used to find the address associated with a kernel symbol.

  [1]: https://github.com/torvalds/linux/commit/0bd476e6c67190b5eb7b6e105c8db8ff61103281
  [2]: https://lwn.net/ml/linux-kernel/20200221232746.6eb84111a0d385bed71613ff@kernel.org/